### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/mtcteam/4d41cc78-22a2-4a3a-b74d-42809ebdb0fd/7588103a-26e5-40fb-8f05-816ed1e1a228/_apis/work/boardbadge/271a648a-40c9-4e02-a4cd-4ccc13a655c5)](https://dev.azure.com/mtcteam/4d41cc78-22a2-4a3a-b74d-42809ebdb0fd/_boards/board/t/7588103a-26e5-40fb-8f05-816ed1e1a228/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#423](https://dev.azure.com/mtcteam/4d41cc78-22a2-4a3a-b74d-42809ebdb0fd/_workitems/edit/423). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.